### PR TITLE
added a timer on Windows

### DIFF
--- a/Example/Example.cpp
+++ b/Example/Example.cpp
@@ -34,10 +34,21 @@ int main()
 
 	window->keyEvent = HandleKeyPresses;
 	window->mouseWheelEvent = HandleMouseWheel;
+
+	// done as a lambda so that we keep access to manager
+	window->mouseButtonEvent = [&](TinyWindow::mouseButton_t mouseButton, buttonState_t buttonState)
+	{
+		if (TinyWindow::mouseButton_t::left == mouseButton && TinyWindow::buttonState_t::down == buttonState)
+		{
+			printf("time %lf\n", manager->GetTime());
+		}
+	};
+
 	glClearColor(0.25f, 0.25f, 0.25f, 1.0f);
 	while (!window->shouldClose)
 	{
 		manager->PollForEvents();
+
 
 		window->SwapDrawBuffers();
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);


### PR DESCRIPTION
TinyWindow does not have a timer/clock/whatnot

Conventional wisdom (for Windows anyway) is to use [QueryPerformanceCounter](https://msdn.microsoft.com/en-us/library/windows/desktop/ms644904%28v=vs.85%29.aspx) and [QueryPerformanceFrequency](https://msdn.microsoft.com/en-us/library/windows/desktop/ms644905%28v=vs.85%29.aspx) to convert it to a usable time stamp.

So this is a simple change to the `master` branch that adds that feature.

(I don't have easy access to a Linux system so I haven't tried to do anything there)
