### PR TITLE
Resolved an issue where many events were not processed

### DIFF
--- a/Include/TinyWindow.h
+++ b/Include/TinyWindow.h
@@ -1848,7 +1848,7 @@ namespace TinyWindow
 			mask |= ExposureMask;
 			
 			/** Listen to events associated with the specified event mask. */
-			XSelectInput(currentDisplay, XDefaultRootWindow(currentDisplay), StructureNotifyMask);
+			XSelectInput(currentDisplay, XDefaultRootWindow(currentDisplay), mask);
     #endif
 
 

--- a/Include/TinyWindow.h
+++ b/Include/TinyWindow.h
@@ -1838,6 +1838,17 @@ namespace TinyWindow
             screenResolution.y = HeightOfScreen(
                 XScreenOfDisplay(currentDisplay,
                     DefaultScreen(currentDisplay)));*/
+			
+			unsigned long mask = 0;
+		
+			mask |= KeyPressMask | KeyReleaseMask;
+			mask |= ButtonPressMask | ButtonReleaseMask | ButtonMotionMask;
+			mask |= PointerMotionMask | EnterWindowMask | LeaveWindowMask;
+			mask |= StructureNotifyMask | PropertyChangeMask | FocusChangeMask;
+			mask |= ExposureMask;
+			
+			/** Listen to events associated with the specified event mask. */
+			XSelectInput(currentDisplay, XDefaultRootWindow(currentDisplay), StructureNotifyMask);
     #endif
 
 

--- a/Include/TinyWindow.h
+++ b/Include/TinyWindow.h
@@ -4112,14 +4112,15 @@ namespace TinyWindow
                 return TinyWindow::error_t::linuxCannotCreateWindow;
                 exit(0);
             }
+			// @lp64ace, atoms need to be loaded before calling #XSetWMProtocols below, since it uses the AtomClose!
+			window->currentDisplay = currentDisplay;
+			window->InitializeAtoms();
 
             XMapWindow(currentDisplay, window->windowHandle);
-            XStoreName(currentDisplay, window->windowHandle,
-                window->settings.name);
+            XStoreName(currentDisplay, window->windowHandle, window->settings.name);
 
             XSetWMProtocols(currentDisplay, window->windowHandle, &window->AtomClose, true);    
 
-            window->currentDisplay = currentDisplay;
             InitializeGL(window);
             
             return TinyWindow::error_t::success;
@@ -5134,7 +5135,6 @@ namespace TinyWindow
                 window->position.y = attributes.y;
 
                 window->contextCreated = true;
-                window->InitializeAtoms();
 
 
                 return TinyWindow::error_t::success;


### PR DESCRIPTION
In my Ubuntu system the only events that were handled were resize and drag events, so I added these lines to request from the X server to post key, button, pointer and window update events as well.
```cpp
unsigned long mask = 0;
		
mask |= KeyPressMask | KeyReleaseMask;
mask |= ButtonPressMask | ButtonReleaseMask | ButtonMotionMask;
mask |= PointerMotionMask | EnterWindowMask | LeaveWindowMask;
mask |= StructureNotifyMask | PropertyChangeMask | FocusChangeMask;
mask |= ExposureMask;

/** Listen to events associated with the specified event mask. */
XSelectInput(currentDisplay, XDefaultRootWindow(currentDisplay), mask);
```
Also the destroy event was not received by any of the windows I created and I fixed that by moving the Atom loading before #XSetWMProtocols is called since it uses the #AtomClose atom.
```cpp
// @lp64ace, atoms need to be loaded before calling #XSetWMProtocols below, since it uses the AtomClose!
window->currentDisplay = currentDisplay;
window->InitializeAtoms();
```
This was done right after the Initialization of OpenGL which was too late.