### PR TITLE
Resolved an issue with root window events

### DIFF
--- a/Include/TinyWindow.h
+++ b/Include/TinyWindow.h
@@ -4155,6 +4155,11 @@ namespace TinyWindow
         void Linux_ProcessEvents(XEvent currentEvent)
         {
             tWindow* window = GetWindowByEvent(currentEvent);
+			
+			/** Some events we receive do not have a valid window, since they are dispatched to the root window. */
+			if(!window) {
+				return;
+			}
 
             switch (currentEvent.type)    
             {


### PR DESCRIPTION
Since `XSelectInput` is called on the #XDefaultRootWindow we sometimes get the root window or invalid windows on the `Linux_ProcessEvents` callback.
```
/** Some events we receive do not have a valid window, since they are dispatched to the root window. */
if(!window) {
	return;
}
```