### PR TITLE
Resolved issue with GLX over SSH

### DIFF
--- a/Include/TinyWindow.h
+++ b/Include/TinyWindow.h
@@ -1838,17 +1838,6 @@ namespace TinyWindow
             screenResolution.y = HeightOfScreen(
                 XScreenOfDisplay(currentDisplay,
                     DefaultScreen(currentDisplay)));*/
-			
-			unsigned long mask = 0;
-		
-			mask |= KeyPressMask | KeyReleaseMask;
-			mask |= ButtonPressMask | ButtonReleaseMask | ButtonMotionMask;
-			mask |= PointerMotionMask | EnterWindowMask | LeaveWindowMask;
-			mask |= StructureNotifyMask | PropertyChangeMask | FocusChangeMask;
-			mask |= ExposureMask;
-			
-			/** Listen to events associated with the specified event mask. */
-			XSelectInput(currentDisplay, XDefaultRootWindow(currentDisplay), mask);
     #endif
 
 
@@ -4131,6 +4120,17 @@ namespace TinyWindow
             XStoreName(currentDisplay, window->windowHandle, window->settings.name);
 
             XSetWMProtocols(currentDisplay, window->windowHandle, &window->AtomClose, true);    
+			
+            unsigned long mask = 0;
+		
+            mask |= KeyPressMask | KeyReleaseMask;
+            mask |= ButtonPressMask | ButtonReleaseMask | ButtonMotionMask;
+            mask |= PointerMotionMask | EnterWindowMask | LeaveWindowMask;
+            mask |= PropertyChangeMask | FocusChangeMask;
+            mask |= ExposureMask;
+			
+			/** Listen to events associated with the specified event mask. */
+            XSelectInput(currentDisplay, window->windowHandle, mask);
 
             InitializeGL(window);
             


### PR DESCRIPTION
After fucking around a bit I found out that creating an OpenGL context over SSH failed! `glXChooseVisual`, turns out, is sending some messages to the root window, since It needs to get some visual information I guess and these messages were intercepted by the `XSelectInput` that was added on the root window, and where failing because we do not have permission to alter root window data.

I moved the `XSelectInput` after the window creation in order to tackle that and made it per window instead of the root window.

```cpp
unsigned long mask = 0;

mask |= KeyPressMask | KeyReleaseMask;
mask |= ButtonPressMask | ButtonReleaseMask | ButtonMotionMask;
mask |= PointerMotionMask | EnterWindowMask | LeaveWindowMask;
mask |= PropertyChangeMask | FocusChangeMask;
mask |= ExposureMask;

/** Listen to events associated with the specified event mask. */
XSelectInput(currentDisplay, window->windowHandle /** per window instead of root window */, mask);
```

Also adding the `StructureNotifyMask` in `mask` seems to increase the delay of the events through SSH and add problems with event handing for some unkown to me reason, so I removed that! Events on my own implementation seem to work magnificently on [lp64ace/rose](https://github.com/lp64ace/rose) even through SSH while on the example provided here events over SSH have a somewhat big delay when handled, native Ubuntu works perfectly for both my implementation and the example provided.

