### PR TITLE
Resize Events for both Linux and Windows.

### DIFF
--- a/Include/TinyWindow.h
+++ b/Include/TinyWindow.h
@@ -2347,12 +2347,12 @@ namespace TinyWindow
                 {
                     RECT tempRect;
                     GetWindowRect(window->windowHandle, &tempRect);
-                    window->settings.resolution.width = tempRect.right;
-                    window->settings.resolution.height = tempRect.bottom;
+                    window->settings.resolution.width = tempRect.right - tempRect.left;
+                    window->settings.resolution.height = tempRect.bottom - tempRect.top;
 
                     GetClientRect(window->windowHandle, &tempRect);
-                    window->clientArea.width = tempRect.right;
-                    window->clientArea.height = tempRect.bottom;
+                    window->clientArea.width = tempRect.right - tempRect.left;
+                    window->clientArea.height = tempRect.bottom - tempRect.top;
 
                     if (manager->resizeEvent != nullptr)
                     {

--- a/Include/TinyWindow.h
+++ b/Include/TinyWindow.h
@@ -4141,7 +4141,8 @@ namespace TinyWindow
             mask |= KeyPressMask | KeyReleaseMask;
             mask |= ButtonPressMask | ButtonReleaseMask | ButtonMotionMask;
             mask |= PointerMotionMask | EnterWindowMask | LeaveWindowMask;
-            mask |= StructureNotifyMask | PropertyChangeMask | FocusChangeMask;
+            mask |= SubstructureNotifyMask | StructureNotifyMask;
+            mask |= PropertyChangeMask | FocusChangeMask;
             mask |= ExposureMask;
 			
 			/** Listen to events associated with the specified event mask. */

--- a/Include/TinyWindow.h
+++ b/Include/TinyWindow.h
@@ -2313,7 +2313,6 @@ namespace TinyWindow
 					 * while here we override them with the dimensions of the client area.
 					 */
 					
-					//high and low word are the client resolution. will need to change this
                     window->clientArea.width = (unsigned int)LOWORD(longParam);
                     window->clientArea.height = (unsigned int)HIWORD(longParam);
 

--- a/Include/TinyWindow.h
+++ b/Include/TinyWindow.h
@@ -2321,8 +2321,8 @@ namespace TinyWindow
 					 */
 					RECT tempRect;
                     GetWindowRect(window->windowHandle, &tempRect);
-                    window->resolution.width = tempRect.right - tempRect.left;
-                    window->resolution.height = tempRect.bottom - tempRect.top;
+                    window->settings.resolution.width = tempRect.right - tempRect.left;
+                    window->settings.resolution.height = tempRect.bottom - tempRect.top;
 
                     switch (wordParam)
                     {

--- a/Include/TinyWindow.h
+++ b/Include/TinyWindow.h
@@ -4126,7 +4126,7 @@ namespace TinyWindow
             mask |= KeyPressMask | KeyReleaseMask;
             mask |= ButtonPressMask | ButtonReleaseMask | ButtonMotionMask;
             mask |= PointerMotionMask | EnterWindowMask | LeaveWindowMask;
-            mask |= PropertyChangeMask | FocusChangeMask;
+            mask |= StructureNotifyMask | PropertyChangeMask | FocusChangeMask;
             mask |= ExposureMask;
 			
 			/** Listen to events associated with the specified event mask. */

--- a/Include/TinyWindow.h
+++ b/Include/TinyWindow.h
@@ -1838,17 +1838,6 @@ namespace TinyWindow
             screenResolution.y = HeightOfScreen(
                 XScreenOfDisplay(currentDisplay,
                     DefaultScreen(currentDisplay)));*/
-			
-			unsigned long mask = 0;
-		
-			mask |= KeyPressMask | KeyReleaseMask;
-			mask |= ButtonPressMask | ButtonReleaseMask | ButtonMotionMask;
-			mask |= PointerMotionMask | EnterWindowMask | LeaveWindowMask;
-			mask |= StructureNotifyMask | PropertyChangeMask | FocusChangeMask;
-			mask |= ExposureMask;
-			
-			/** Listen to events associated with the specified event mask. */
-			XSelectInput(currentDisplay, XDefaultRootWindow(currentDisplay), mask);
     #endif
 
 
@@ -4131,6 +4120,17 @@ namespace TinyWindow
             XStoreName(currentDisplay, window->windowHandle, window->settings.name);
 
             XSetWMProtocols(currentDisplay, window->windowHandle, &window->AtomClose, true);    
+			
+            unsigned long mask = 0;
+		
+            mask |= KeyPressMask | KeyReleaseMask;
+            mask |= ButtonPressMask | ButtonReleaseMask | ButtonMotionMask;
+            mask |= PointerMotionMask | EnterWindowMask | LeaveWindowMask;
+            mask |= PropertyChangeMask | FocusChangeMask;
+            mask |= ExposureMask;
+			
+			/** Listen to events associated with the specified event mask. */
+            XSelectInput(currentDisplay, window->windowHandle, mask);
 
             InitializeGL(window);
             

--- a/Include/TinyWindow.h
+++ b/Include/TinyWindow.h
@@ -2316,14 +2316,13 @@ namespace TinyWindow
                     window->clientArea.width = (unsigned int)LOWORD(longParam);
                     window->clientArea.height = (unsigned int)HIWORD(longParam);
 
+					/**
+					 * Also since WM_SIZE is received by the window "after its size has changed".
+					 */
 					RECT tempRect;
-                    GetClientRect(window->windowHandle, &tempRect);
-                    LONG cx = tempRect.right - tempRect.left;
-                    LONG cy = tempRect.bottom - tempRect.top;
-					
                     GetWindowRect(window->windowHandle, &tempRect);
-                    window->resolution.width = window->clientArea.width + (tempRect.right - tempRect.left) - cx;
-                    window->resolution.height = window->clientArea.height + (tempRect.bottom - tempRect.top) - cy;
+                    window->resolution.width = tempRect.right - tempRect.left;
+                    window->resolution.height = tempRect.bottom - tempRect.top;
 
                     switch (wordParam)
                     {


### PR DESCRIPTION
Fixed an issue where the resolution was calculated wrong on size events on windows.
```cpp
RECT tempRect;
GetWindowRect(window->windowHandle, &tempRect);
window->settings.resolution.width = tempRect.right; // - tempRect.left; <<< this was missing.
window->settings.resolution.height = tempRect.bottom; // - tempRect.top; <<< this was missing.
```

Fixed an issue where I would get flickering images because of inconsistent arguments on window resize on windows.
```cpp
window->clientArea.width = (unsigned int)LOWORD(longParam); // <<< this was stored in the window resolution instead.
window->clientArea.height = (unsigned int)HIWORD(longParam); // <<< this was stored in the window resolution instead.
```

Added structure notify mask for Linux because otherwise no resize events were triggered! Also the `XSelectInput` was moved per window because otherwise unless you had sudo access in Linux the application failed to get `glXChooseVisual`
```cpp
mask |= StructureNotifyMask
```